### PR TITLE
Change inline SVGs id hashing strategy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "web-contrib",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-contrib",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Extensions for dependencies of Web Projects (PWA)",
   "main": "./lib/extensions/react-redux/injectReducer.js",
   "jsnext:main": "src/extensions/react-redux/injectReducer.js",

--- a/webpack/base.config.js
+++ b/webpack/base.config.js
@@ -3,9 +3,7 @@
  */
 
 const path = require('path');
-const { relative } = require('path');
 const hash = require('string-hash');
-const context = __dirname;
 const webpack = require('webpack');
 const HappyPack = require('happypack');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
@@ -116,7 +114,7 @@ module.exports = (options) => ({
                 plugins: [
                   { removeStyleElement: true },
                   { removeTitle: true },
-                  { cleanupIDs: { minify: true, prefix: `${hash(relative(context, resource))}_` } },
+                  { cleanupIDs: { minify: true, prefix: `${hash(resource)}_` } },
                 ],
               },
             },


### PR DESCRIPTION
Currently, `id`s in inlined SVGs are minified and prefixed by a hash based on the relative filepath.

This PR changes the hashing strategy to use the absolute path instead of the relative one. This way, it's easier to replicate the react-svg-loader configuration for SSR and prevent mismatch errors (i.e. `id did not match`).