### PR TITLE
Disable HappyPack log

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "web-contrib",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-contrib",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Extensions for dependencies of Web Projects (PWA)",
   "main": "./lib/extensions/react-redux/injectReducer.js",
   "jsnext:main": "src/extensions/react-redux/injectReducer.js",

--- a/webpack/base.config.js
+++ b/webpack/base.config.js
@@ -185,6 +185,7 @@ module.exports = (options) => {
             query: { happyPackMode: true },
           },
         ],
+        verbose: false,
       }),
       new HappyPack({
         id: 'js',
@@ -196,6 +197,7 @@ module.exports = (options) => {
             query: options.babelQuery,
           },
         ],
+        verbose: false,
       }),
 
       new webpack.ProvidePlugin({


### PR DESCRIPTION
# What this PR do

Adds `verbose: false` to HappyPack configuration.

## Why

We are experiment ways to integrate bundle sizes reports to the CI. One way to accomplish this is by comparing webpacks json output. HappyPack logs bellow are being saved inside the json and is corrupting the webpack json:

```
Happy[ts]: Version: 5.0.1. Threads: 1
Happy[ts]: All set; signaling webpack to proceed.
Happy[js]: Version: 5.0.1. Threads: 2
Happy[js]: All set; signaling webpack to proceed.
```

You can check [the PR 3600 in pwa-tenants](https://github.com/quintoandar/pwa-tenants/pull/3600) for more informations.
