### PR TITLE
(fix) Option resolve.alias

### DIFF
--- a/webpack/base.config.js
+++ b/webpack/base.config.js
@@ -229,7 +229,7 @@ module.exports = (options) => {
         'browser',
         'main',
       ],
-      alias: options.alias,
+      alias: options.resolve.alias,
     },
     devtool: options.devtool,
     target: 'web', // Make web variables accessible to webpack, e.g. window


### PR DESCRIPTION
# Description

Config `alias` under `resolve` should map to option `options.resolve.alias`.