### PR TITLE
Lock Immutable to 4.0.0-rc.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4397,9 +4397,9 @@
       "dev": true
     },
     "immutable": {
-      "version": "4.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.0.0-rc.9.tgz",
-      "integrity": "sha512-uw4u9Jy3G2Y1qkIFtEGy9NgJxFJT1l3HKgeSFHfrvy91T8W54cJoQ+qK3fTwhil8XkEHuc2S+MI+fbD0vKObDA=="
+      "version": "4.0.0-rc.4",
+      "resolved": "https://verdaccio.forno.quintoandar.com.br/immutable/-/immutable-4.0.0-rc.4.tgz",
+      "integrity": "sha512-1oi1vdL+bYEsswc5lnBwPJs+W9KiAGP1WzqqyH/Oamm4r6SSi8K67ZduPbwuE+OkijNbJJ9oTklwjEppEdGTiw=="
     },
     "import-local": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -351,7 +351,7 @@
     "assets-webpack-plugin": "^3.8.4",
     "extract-text-webpack-plugin": "^3.0.2",
     "happypack": "^5.0.0",
-    "immutable": "^4.0.0-rc.4",
+    "immutable": "4.0.0-rc.4",
     "lodash": "^4.17.4",
     "react-router": "^3.0.5",
     "react-router-redux": "^4.0.6",


### PR DESCRIPTION
# Description

Immutable versions above rc.4 comes with breaking changes that are too complex for a single refactor.
This PR locks to the version 4.0.0-rc.4.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
