### PR TITLE
Webpack: babel transpiles mjs and cjs files

### DIFF
--- a/webpack/base.config.js
+++ b/webpack/base.config.js
@@ -91,7 +91,7 @@ module.exports = (options) => {
           loader: 'happypack/loader?id=ts',
         },
         {
-          test: /\.jsx?$/,
+          test: /\.m?c?jsx?$/,
           exclude: options.excludeFunc,
           loader: 'happypack/loader?id=js',
         }, {


### PR DESCRIPTION
Webpack: babel transpiles .mjs and .cjs files.

Take a look at the regex tests: https://regexr.com/5q556